### PR TITLE
Passing TimeInit as a not loga.

### DIFF
--- a/libgadget/init.c
+++ b/libgadget/init.c
@@ -59,7 +59,7 @@ void init(int RestartSnapNum)
         }
     }
 
-    init_timebins(log(All.TimeInit));
+    init_timebins(All.TimeInit);
 
     /* Important to set the global time before reading in the snapshot time as it affects the GT funcs for IO. */
     set_global_time(exp(loga_from_ti(All.Ti_Current)));

--- a/libgadget/timebinmgr.c
+++ b/libgadget/timebinmgr.c
@@ -12,13 +12,15 @@ static int NSyncPoints;    /* number of times stored in table of desired sync po
 
 /* This function compiles
  *
- * All.OutputListTimes, All.TimeInit, All.TimeMax
+ * All.OutputListTimes, All.TimeIC, All.TimeMax
  *
  * into a list of SyncPoint objects.
  *
  * A SyncPoint is a time step where all state variables are at the same time on the
  * KkdkK timeline.
  *
+ * TimeIC and TimeMax are used to ensure restarting from snapshot obtains exactly identical
+ * integer stamps.
  **/
 void
 setup_sync_points(double TimeIC, double no_snapshot_until_time)

--- a/libgadget/timestep.c
+++ b/libgadget/timestep.c
@@ -76,10 +76,11 @@ static inttime_t get_long_range_timestep_ti(const inttime_t dti_max);
 void
 init_timebins(double TimeInit)
 {
-    All.Ti_Current = ti_from_loga(TimeInit);
+    All.Ti_Current = ti_from_loga(log(TimeInit));
     /*Enforce Ti_Current is initially even*/
     if(All.Ti_Current % 2 == 1)
         All.Ti_Current++;
+    message(0, "Initial TimeStep at TimeInit %g Ti_Current = %d \n", TimeInit, All.Ti_Current);
     /* this makes sure the first step is a PM step. */
     PM.length = 0;
     PM.Ti_kick = All.Ti_Current;


### PR DESCRIPTION
The function is used only once, so it doesn't hurt to move log() inside
the function call. Less overall confusion. Also prints a message about
the very first Ti_Current. May be a useful diagonostic if things go wrong.